### PR TITLE
Fix Jest configuration for backend TypeScript tests

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};


### PR DESCRIPTION
## Summary
- add `jest.config.js` in backend to use `ts-jest`

## Testing
- `npm test` in `backend`